### PR TITLE
Remove cop that no longer exists

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -16,7 +16,10 @@ Style/Documentation:
 Style/Send:
   Enabled: true
 
-TrailingComma:
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArguments:
  EnforcedStyleForMultiline: comma
 
 Style/SymbolArray:


### PR DESCRIPTION
The `Style/TrailingComma`  cop no longer exists. So is replaced by `Style/TrailingCommaInLiteral` and `Style/TrailingCommaInArguments`
